### PR TITLE
fix: show process info when port is in use

### DIFF
--- a/cmd/port-selector/main.go
+++ b/cmd/port-selector/main.go
@@ -308,7 +308,10 @@ func lockSpecificPort(allocs *allocations.AllocationList, portArg int, cwd strin
 	}
 
 	if !port.IsPortFree(portArg) {
-		return 0, fmt.Errorf("port %d is not available (in use by another process)", portArg)
+		if procInfo := port.GetPortProcess(portArg); procInfo != nil {
+			return 0, fmt.Errorf("port %d is in use by another process (%s)", portArg, procInfo)
+		}
+		return 0, fmt.Errorf("port %d is in use by another process", portArg)
 	}
 
 	existingAlloc := allocs.FindByDirectory(cwd)

--- a/cmd/port-selector/main_test.go
+++ b/cmd/port-selector/main_test.go
@@ -278,8 +278,8 @@ func TestLockPortInUseByAnotherProcess(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error, got success with output: %s", output)
 	}
-	if !strings.Contains(string(output), "not available") {
-		t.Errorf("expected 'not available' error, got: %s", output)
+	if !strings.Contains(string(output), "in use") {
+		t.Errorf("expected 'in use' error, got: %s", output)
 	}
 }
 

--- a/internal/port/procinfo.go
+++ b/internal/port/procinfo.go
@@ -1,0 +1,175 @@
+package port
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// ProcessInfo contains information about a process using a port.
+type ProcessInfo struct {
+	PID     int
+	Name    string
+	Cwd     string // working directory
+	Cmdline string // command line (truncated)
+}
+
+// String returns a human-readable description of the process.
+func (p *ProcessInfo) String() string {
+	if p == nil {
+		return "unknown process"
+	}
+
+	parts := []string{fmt.Sprintf("pid=%d", p.PID)}
+
+	if p.Name != "" {
+		parts = append(parts, p.Name)
+	}
+
+	if p.Cwd != "" {
+		parts = append(parts, fmt.Sprintf("cwd=%s", p.Cwd))
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+// GetPortProcess returns information about the process using the given port.
+// Returns nil if the process cannot be determined (e.g., permission denied).
+func GetPortProcess(port int) *ProcessInfo {
+	// Try both IPv4 and IPv6
+	if info := getPortProcessFromProc(port, "/proc/net/tcp"); info != nil {
+		return info
+	}
+	return getPortProcessFromProc(port, "/proc/net/tcp6")
+}
+
+// getPortProcessFromProc parses /proc/net/tcp or /proc/net/tcp6 to find the inode,
+// then searches /proc/*/fd/ to find which process owns that socket.
+func getPortProcessFromProc(port int, procNetFile string) *ProcessInfo {
+	inode := findSocketInode(port, procNetFile)
+	if inode == 0 {
+		return nil
+	}
+
+	pid := findProcessByInode(inode)
+	if pid == 0 {
+		return nil
+	}
+
+	return getProcessInfo(pid)
+}
+
+// findSocketInode searches /proc/net/tcp(6) for a listening socket on the given port.
+// Returns the inode number or 0 if not found.
+func findSocketInode(port int, procNetFile string) uint64 {
+	file, err := os.Open(procNetFile)
+	if err != nil {
+		return 0
+	}
+	defer file.Close()
+
+	// Port in hex (network byte order for local port)
+	portHex := fmt.Sprintf("%04X", port)
+
+	scanner := bufio.NewScanner(file)
+	scanner.Scan() // skip header line
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		if len(fields) < 10 {
+			continue
+		}
+
+		// Field 1 is local_address (hex_ip:hex_port)
+		localAddr := fields[1]
+		parts := strings.Split(localAddr, ":")
+		if len(parts) != 2 {
+			continue
+		}
+
+		localPort := parts[1]
+		if localPort != portHex {
+			continue
+		}
+
+		// Field 3 is state: 0A = LISTEN
+		if fields[3] != "0A" {
+			continue
+		}
+
+		// Field 9 is inode
+		inode, err := strconv.ParseUint(fields[9], 10, 64)
+		if err != nil {
+			continue
+		}
+
+		return inode
+	}
+
+	return 0
+}
+
+// findProcessByInode searches /proc/*/fd/ for a socket with the given inode.
+// Returns the PID or 0 if not found.
+func findProcessByInode(inode uint64) int {
+	socketLink := fmt.Sprintf("socket:[%d]", inode)
+
+	procDirs, err := os.ReadDir("/proc")
+	if err != nil {
+		return 0
+	}
+
+	for _, entry := range procDirs {
+		if !entry.IsDir() {
+			continue
+		}
+
+		// Check if directory name is a PID (numeric)
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+
+		fdDir := filepath.Join("/proc", entry.Name(), "fd")
+		fds, err := os.ReadDir(fdDir)
+		if err != nil {
+			continue // permission denied or process gone
+		}
+
+		for _, fd := range fds {
+			link, err := os.Readlink(filepath.Join(fdDir, fd.Name()))
+			if err != nil {
+				continue
+			}
+
+			if link == socketLink {
+				return pid
+			}
+		}
+	}
+
+	return 0
+}
+
+// getProcessInfo reads process information from /proc/[pid]/.
+func getProcessInfo(pid int) *ProcessInfo {
+	info := &ProcessInfo{PID: pid}
+
+	procDir := fmt.Sprintf("/proc/%d", pid)
+
+	// Read process name from /proc/[pid]/comm
+	if data, err := os.ReadFile(filepath.Join(procDir, "comm")); err == nil {
+		info.Name = strings.TrimSpace(string(data))
+	}
+
+	// Read working directory from /proc/[pid]/cwd
+	if cwd, err := os.Readlink(filepath.Join(procDir, "cwd")); err == nil {
+		info.Cwd = cwd
+	}
+
+	return info
+}

--- a/internal/port/procinfo_test.go
+++ b/internal/port/procinfo_test.go
@@ -1,0 +1,102 @@
+package port
+
+import (
+	"net"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestProcessInfo_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		info     *ProcessInfo
+		contains []string
+	}{
+		{
+			name: "full info",
+			info: &ProcessInfo{
+				PID:  12345,
+				Name: "myapp",
+				Cwd:  "/home/user/project",
+			},
+			contains: []string{"pid=12345", "myapp", "cwd=/home/user/project"},
+		},
+		{
+			name: "pid only",
+			info: &ProcessInfo{
+				PID: 12345,
+			},
+			contains: []string{"pid=12345"},
+		},
+		{
+			name:     "nil info",
+			info:     nil,
+			contains: []string{"unknown process"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.info.String()
+			for _, s := range tt.contains {
+				if !strings.Contains(result, s) {
+					t.Errorf("String() = %q, want to contain %q", result, s)
+				}
+			}
+		})
+	}
+}
+
+func TestGetPortProcess_OwnProcess(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("GetPortProcess only works on Linux")
+	}
+
+	// Start a listener on a random port
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start listener: %v", err)
+	}
+	defer ln.Close()
+
+	// Get the port
+	addr := ln.Addr().(*net.TCPAddr)
+	port := addr.Port
+
+	// Get process info for our own process
+	info := GetPortProcess(port)
+	if info == nil {
+		t.Fatal("GetPortProcess returned nil for our own listening port")
+	}
+
+	// Should be our own PID
+	if info.PID != os.Getpid() {
+		t.Errorf("PID = %d, want %d", info.PID, os.Getpid())
+	}
+
+	// Should have a process name
+	if info.Name == "" {
+		t.Error("Name is empty")
+	}
+
+	// Should have a cwd (our working directory)
+	if info.Cwd == "" {
+		t.Error("Cwd is empty")
+	}
+}
+
+func TestGetPortProcess_NoListener(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("GetPortProcess only works on Linux")
+	}
+
+	// Use a port that's unlikely to be in use
+	info := GetPortProcess(59999)
+
+	// Should return nil for a port with no listener
+	if info != nil {
+		t.Errorf("GetPortProcess returned non-nil for unused port: %+v", info)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds detailed process information when `--lock` fails due to port being occupied
- Shows PID, process name, and working directory of the blocking process
- Helps users quickly identify what's using the port

Closes #20

## Example

Before:
```
error: port 3000 is not available (in use by another process)
```

After:
```
error: port 3000 is in use by another process (pid=876344, ruby, cwd=/home/user/myapp)
```

## Changes

- `internal/port/procinfo.go` — new function `GetPortProcess()` that:
  - Parses `/proc/net/tcp` and `/proc/net/tcp6` to find socket inode
  - Searches `/proc/[pid]/fd/` to find owning process
  - Reads process name from `/proc/[pid]/comm` and cwd from `/proc/[pid]/cwd`
- `cmd/port-selector/main.go` — uses new function in error message
- Added tests for new functionality

## Test plan

- [x] `go test ./...` passes
- [x] Manual test on occupied port shows correct process info
- [x] Works for both IPv4 and IPv6 listeners

🤖 Generated with [Claude Code](https://claude.com/claude-code)