### PR TITLE
feat: add ss fallback for process discovery and show socket owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,32 @@ After 4000:   checks 3000 (wrap-around)
                                └────────────────┘
 ```
 
+## Optional Dependencies
+
+### ss (socket statistics)
+
+The `ss` command from [iproute2](https://wiki.linuxfoundation.org/networking/iproute2) is used as a fallback for process discovery when `/proc/PID/fd/` is not accessible. This improves process detection for:
+
+- `--list` command (shows PID and PROCESS columns)
+- `--scan` command (discovers busy ports and their processes)
+
+**Installation:**
+
+```bash
+# Debian/Ubuntu
+sudo apt install iproute2
+
+# RHEL/CentOS/Fedora
+sudo dnf install iproute
+
+# Alpine
+apk add iproute2
+```
+
+Most Linux distributions include `iproute2` by default. If `ss` is not available, `port-selector` will still work but may not be able to identify processes in some cases.
+
+**Note:** Even with `ss`, process information for root-owned processes (like `docker-proxy`) requires elevated permissions. For full Docker port detection, see [#29](https://github.com/dapi/port-selector/issues/29).
+
 ## Development
 
 ### Requirements

--- a/README.ru.md
+++ b/README.ru.md
@@ -387,6 +387,32 @@ allocationTTL: 30d  # Аллокации истекают после 30 дней
                                └────────────────┘
 ```
 
+## Опциональные зависимости
+
+### ss (socket statistics)
+
+Команда `ss` из пакета [iproute2](https://wiki.linuxfoundation.org/networking/iproute2) используется как fallback для обнаружения процессов, когда `/proc/PID/fd/` недоступен. Это улучшает определение процессов для:
+
+- Команды `--list` (показывает колонки PID и PROCESS)
+- Команды `--scan` (обнаруживает занятые порты и их процессы)
+
+**Установка:**
+
+```bash
+# Debian/Ubuntu
+sudo apt install iproute2
+
+# RHEL/CentOS/Fedora
+sudo dnf install iproute
+
+# Alpine
+apk add iproute2
+```
+
+Большинство дистрибутивов Linux включают `iproute2` по умолчанию. Если `ss` недоступен, `port-selector` продолжит работать, но в некоторых случаях не сможет определить процессы.
+
+**Примечание:** Даже с `ss`, информация о процессах для root-процессов (например, `docker-proxy`) требует повышенных привилегий. Для полного определения Docker-портов смотрите [#29](https://github.com/dapi/port-selector/issues/29).
+
 ## Разработка
 
 ### Требования

--- a/internal/port/procinfo.go
+++ b/internal/port/procinfo.go
@@ -4,7 +4,10 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"os/exec"
+	"os/user"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -15,6 +18,8 @@ type ProcessInfo struct {
 	Name    string
 	Cwd     string // working directory
 	Cmdline string // command line (truncated)
+	UID     int    // user ID owning the socket
+	User    string // username (resolved from UID)
 }
 
 // String returns a human-readable description of the process.
@@ -37,37 +42,79 @@ func (p *ProcessInfo) String() string {
 }
 
 // GetPortProcess returns information about the process using the given port.
-// Returns nil if the process cannot be determined (e.g., permission denied).
+// Returns nil if the process cannot be determined.
+// Always returns at least UID/User if the socket is found in /proc/net/tcp.
+// Falls back to parsing `ss -tlnp` output to get process name when PID is not accessible.
 func GetPortProcess(port int) *ProcessInfo {
-	// Try both IPv4 and IPv6
-	if info := getPortProcessFromProc(port, "/proc/net/tcp"); info != nil {
+	// Try both IPv4 and IPv6 via /proc
+	info := getPortProcessFromProc(port, "/proc/net/tcp")
+	if info == nil {
+		info = getPortProcessFromProc(port, "/proc/net/tcp6")
+	}
+	if info == nil {
+		return nil
+	}
+
+	// If we have full info (PID found), return it
+	if info.PID != 0 {
 		return info
 	}
-	return getPortProcessFromProc(port, "/proc/net/tcp6")
+
+	// We have UID but no PID - try ss fallback to get process name
+	if ssInfo := getPortProcessFromSS(port); ssInfo != nil {
+		info.PID = ssInfo.PID
+		info.Name = ssInfo.Name
+		if ssInfo.Cwd != "" {
+			info.Cwd = ssInfo.Cwd
+		}
+	}
+
+	return info
 }
 
 // getPortProcessFromProc parses /proc/net/tcp or /proc/net/tcp6 to find the inode,
 // then searches /proc/*/fd/ to find which process owns that socket.
+// Returns ProcessInfo with at least UID/User if socket found, full info if process accessible.
 func getPortProcessFromProc(port int, procNetFile string) *ProcessInfo {
-	inode := findSocketInode(port, procNetFile)
-	if inode == 0 {
+	sockInfo := findSocketInfo(port, procNetFile)
+	if sockInfo == nil {
 		return nil
 	}
 
-	pid := findProcessByInode(inode)
+	// We have UID from /proc/net/tcp - resolve username
+	info := &ProcessInfo{
+		UID: sockInfo.UID,
+	}
+	if u, err := user.LookupId(strconv.Itoa(sockInfo.UID)); err == nil {
+		info.User = u.Username
+	}
+
+	// Try to find the process by inode
+	pid := findProcessByInode(sockInfo.Inode)
 	if pid == 0 {
-		return nil
+		// Can't find PID (permission denied for /proc/*/fd/), but we have UID
+		return info
 	}
 
-	return getProcessInfo(pid)
+	// We found the PID, get full process info
+	fullInfo := getProcessInfo(pid)
+	fullInfo.UID = info.UID
+	fullInfo.User = info.User
+	return fullInfo
 }
 
-// findSocketInode searches /proc/net/tcp(6) for a listening socket on the given port.
-// Returns the inode number or 0 if not found.
-func findSocketInode(port int, procNetFile string) uint64 {
+// socketInfo contains information extracted from /proc/net/tcp.
+type socketInfo struct {
+	Inode uint64
+	UID   int
+}
+
+// findSocketInfo searches /proc/net/tcp(6) for a listening socket on the given port.
+// Returns socket info (inode and UID) or nil if not found.
+func findSocketInfo(port int, procNetFile string) *socketInfo {
 	file, err := os.Open(procNetFile)
 	if err != nil {
-		return 0
+		return nil
 	}
 	defer file.Close()
 
@@ -101,16 +148,19 @@ func findSocketInode(port int, procNetFile string) uint64 {
 			continue
 		}
 
+		// Field 7 is UID
+		uid, _ := strconv.Atoi(fields[7])
+
 		// Field 9 is inode
 		inode, err := strconv.ParseUint(fields[9], 10, 64)
 		if err != nil {
 			continue
 		}
 
-		return inode
+		return &socketInfo{Inode: inode, UID: uid}
 	}
 
-	return 0
+	return nil
 }
 
 // findProcessByInode searches /proc/*/fd/ for a socket with the given inode.
@@ -172,4 +222,71 @@ func getProcessInfo(pid int) *ProcessInfo {
 	}
 
 	return info
+}
+
+// ssProcessRegex matches the process info in ss output: users:(("name",pid=12345,fd=7))
+var ssProcessRegex = regexp.MustCompile(`users:\(\("([^"]+)",pid=(\d+),fd=\d+\)\)`)
+
+// getPortProcessFromSS uses the `ss` command to get process info for a port.
+// This is a fallback for when /proc/*/fd/ is not accessible (e.g., root-owned processes).
+func getPortProcessFromSS(port int) *ProcessInfo {
+	// Run ss -tlnp to get listening TCP sockets with process info
+	cmd := exec.Command("ss", "-tlnp")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+
+	portStr := fmt.Sprintf(":%d", port)
+
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Check if this line contains our port
+		// Format: "LISTEN 0 4096 127.0.0.1:3000 0.0.0.0:* users:(("ruby",pid=876344,fd=6))"
+		if !strings.Contains(line, portStr) {
+			continue
+		}
+
+		// Verify it's the local address port, not peer port
+		fields := strings.Fields(line)
+		if len(fields) < 4 {
+			continue
+		}
+
+		localAddr := fields[3]
+		// Check if local address ends with our port
+		if !strings.HasSuffix(localAddr, portStr) {
+			continue
+		}
+
+		// Try to extract process info using regex
+		matches := ssProcessRegex.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+
+		name := matches[1]
+		pid, err := strconv.Atoi(matches[2])
+		if err != nil {
+			continue
+		}
+
+		// We have PID and name from ss, now try to get cwd
+		info := &ProcessInfo{
+			PID:  pid,
+			Name: name,
+		}
+
+		// Try to read cwd (may fail for root processes, that's ok)
+		procDir := fmt.Sprintf("/proc/%d", pid)
+		if cwd, err := os.Readlink(filepath.Join(procDir, "cwd")); err == nil {
+			info.Cwd = cwd
+		}
+
+		return info
+	}
+
+	return nil
 }

--- a/internal/port/procinfo_test.go
+++ b/internal/port/procinfo_test.go
@@ -100,3 +100,177 @@ func TestGetPortProcess_NoListener(t *testing.T) {
 		t.Errorf("GetPortProcess returned non-nil for unused port: %+v", info)
 	}
 }
+
+func TestSSProcessRegex(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantName    string
+		wantPID     string
+		shouldMatch bool
+	}{
+		{
+			name:        "standard format",
+			input:       `users:(("ruby",pid=876344,fd=6))`,
+			wantName:    "ruby",
+			wantPID:     "876344",
+			shouldMatch: true,
+		},
+		{
+			name:        "docker-proxy",
+			input:       `users:(("docker-proxy",pid=585980,fd=7))`,
+			wantName:    "docker-proxy",
+			wantPID:     "585980",
+			shouldMatch: true,
+		},
+		{
+			name:        "python process",
+			input:       `users:(("python",pid=466018,fd=4))`,
+			wantName:    "python",
+			wantPID:     "466018",
+			shouldMatch: true,
+		},
+		{
+			name:        "process with hyphen",
+			input:       `users:(("node-server",pid=12345,fd=3))`,
+			wantName:    "node-server",
+			wantPID:     "12345",
+			shouldMatch: true,
+		},
+		{
+			name:        "no process info",
+			input:       `LISTEN 0 4096 127.0.0.1:9099 0.0.0.0:*`,
+			shouldMatch: false,
+		},
+		{
+			name:        "empty string",
+			input:       ``,
+			shouldMatch: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := ssProcessRegex.FindStringSubmatch(tt.input)
+			if tt.shouldMatch {
+				if matches == nil {
+					t.Errorf("regex did not match input: %q", tt.input)
+					return
+				}
+				if len(matches) < 3 {
+					t.Errorf("not enough matches: got %d, want at least 3", len(matches))
+					return
+				}
+				if matches[1] != tt.wantName {
+					t.Errorf("name = %q, want %q", matches[1], tt.wantName)
+				}
+				if matches[2] != tt.wantPID {
+					t.Errorf("PID = %q, want %q", matches[2], tt.wantPID)
+				}
+			} else {
+				if matches != nil {
+					t.Errorf("regex matched when it should not: %v", matches)
+				}
+			}
+		})
+	}
+}
+
+func TestGetPortProcessFromSS_Integration(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("ss command only available on Linux")
+	}
+
+	// Start a listener on a random port
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start listener: %v", err)
+	}
+	defer ln.Close()
+
+	// Get the port
+	addr := ln.Addr().(*net.TCPAddr)
+	port := addr.Port
+
+	// Get process info using ss fallback
+	info := getPortProcessFromSS(port)
+	if info == nil {
+		t.Skip("ss did not return process info (may require permissions)")
+	}
+
+	// Should be our own PID
+	if info.PID != os.Getpid() {
+		t.Errorf("PID = %d, want %d", info.PID, os.Getpid())
+	}
+
+	// Should have a process name
+	if info.Name == "" {
+		t.Error("Name is empty")
+	}
+}
+
+func TestGetPortProcess_ReturnsUID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("GetPortProcess only works on Linux")
+	}
+
+	// Start a listener on a random port
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start listener: %v", err)
+	}
+	defer ln.Close()
+
+	// Get the port
+	addr := ln.Addr().(*net.TCPAddr)
+	port := addr.Port
+
+	// Get process info
+	info := GetPortProcess(port)
+	if info == nil {
+		t.Fatal("GetPortProcess returned nil for our own listening port")
+	}
+
+	// Should have our UID
+	if info.UID != os.Getuid() {
+		t.Errorf("UID = %d, want %d", info.UID, os.Getuid())
+	}
+
+	// Should have resolved username
+	if info.User == "" {
+		t.Error("User is empty")
+	}
+}
+
+func TestFindSocketInfo(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("findSocketInfo only works on Linux")
+	}
+
+	// Start a listener on a random port
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start listener: %v", err)
+	}
+	defer ln.Close()
+
+	// Get the port
+	addr := ln.Addr().(*net.TCPAddr)
+	port := addr.Port
+
+	// Find socket info
+	sockInfo := findSocketInfo(port, "/proc/net/tcp")
+	if sockInfo == nil {
+		t.Fatal("findSocketInfo returned nil for our own listening port")
+	}
+
+	// Should have an inode
+	if sockInfo.Inode == 0 {
+		t.Error("Inode is 0")
+	}
+
+	// Should have our UID
+	if sockInfo.UID != os.Getuid() {
+		t.Errorf("UID = %d, want %d", sockInfo.UID, os.Getuid())
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ss -tlnp` fallback for process discovery when `/proc/PID/fd/` is not accessible
- Extract UID from `/proc/net/tcp` to show socket owner even when PID unavailable
- Add USER column to `--list` output
- Show `user=<username>` in `--scan` when process info unavailable

## Changes

- **procinfo.go**: Added `getPortProcessFromSS()` function, `socketInfo` struct, `findSocketInfo()` function, UID/User fields to ProcessInfo
- **main.go**: Updated `runList()` to show USER column, updated `runScan()` to display user info
- **procinfo_test.go**: Added tests for ss regex parsing, UID extraction
- **README.md / README.ru.md**: Documented `ss` as optional dependency

## Example output

```bash
$ ./port-selector --list
PORT  STATUS  USER   PID      PROCESS  LOCKED  DIRECTORY                    ASSIGNED

$ ./port-selector --scan
Port 3007: used by user=root, cwd unknown, not recorded
```

## Test plan

- [x] Run `go test ./...` - all tests pass
- [x] Test `--list` shows USER column
- [x] Test `--scan` shows user info for root-owned processes
- [x] Verify ss fallback works for own processes

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)