### PR TITLE
feat: --scan records all ports for multi-port directories

### DIFF
--- a/cmd/port-selector/main.go
+++ b/cmd/port-selector/main.go
@@ -567,9 +567,9 @@ func runScan() error {
 				}
 			}
 
-			// Add allocation for this port
+			// Add allocation for this port (don't replace existing ports for same directory)
 			if procInfo != nil && procInfo.Cwd != "" {
-				store.SetAllocationWithProcess(procInfo.Cwd, p, processName)
+				store.AddAllocationForScan(procInfo.Cwd, p, processName)
 			} else {
 				store.SetUnknownPortAllocation(p, processName)
 			}


### PR DESCRIPTION
## Summary
- Added `AddAllocationForScan()` method that preserves existing allocations for the same directory
- Updated `runScan()` to use new method instead of `SetAllocationWithProcess()`
- Allows multi-port projects (e.g., Docker Compose with multiple services) to record all their ports

Closes #48

## Test plan
- [x] Added test `TestAddAllocationForScan_MultiplePortsSameDirectory` - verifies both ports kept
- [x] Added test `TestAddAllocationForScan_UpdatesExistingPort` - verifies same port updates
- [x] Added test `TestAddAllocationForScan_DoesNotAffectSetAllocation` - verifies SetAllocation still replaces
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)