### PR TITLE
fix: update GoReleaser naming to support one-liner install

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,9 +40,8 @@ archives:
     format: binary
 
     name_template: >-
-      {{ .ProjectName }}_
-      {{- .Version }}_
-      {{- .Os }}_
+      {{ .ProjectName }}-
+      {{- .Os }}-
       {{- .Arch }}
 
 checksum:


### PR DESCRIPTION
This PR fixes the broken one-liner installation method.

## Problem
The install.sh script expects binaries named 'port-selector-linux-amd64', but GoReleaser generates 'port-selector_0.9.0_linux_amd64'.

## Solution
Updated .goreleaser.yml to generate binaries without version in filename.

## Testing
After this PR is merged and a new release is created, the one-liner will work:

curl -fsSL https://raw.githubusercontent.com/dapi/port-selector/master/install.sh | sh

Fixes: CI test-install-one-liner failures